### PR TITLE
Unify interpolation functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 num = "0.4.0"
+itertools = "0.10.5"
 
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,4 +4,4 @@ mod twod_lut;
 pub(crate) const EPSILON: f64 = 0.00000001;
 
 pub use oned_lut::{OneDLookUpTable, OneDLookUpTableRef};
-pub use twod_lut::{TwoDLookUpTable, TwoDLookUpTableCow, TwoDLookUpTableRef};
+pub use twod_lut::{TwoDLookUpTable, TwoDLookUpTableRef as TwoDLookUpTableCow, TwoDLookUpTableRef};

--- a/src/twod_lut/interpolation.rs
+++ b/src/twod_lut/interpolation.rs
@@ -58,13 +58,7 @@ fn get_indices(v: &f64, vs: &[f64]) -> (usize, usize) {
     }
 }
 
-pub(in crate::twod_lut) fn interpolate_dynamic(
-    x: &f64,
-    y: &f64,
-    xs: &[f64],
-    ys: &[f64],
-    obj: &dyn SurfaceValueGetter,
-) -> f64 {
+pub(in crate::twod_lut) fn interpolate(x: &f64, y: &f64, xs: &[f64], ys: &[f64], obj: &dyn SurfaceValueGetter) -> f64 {
     // Retrieve the lower and upper bound indices for x and y axes.
     let (x1_ind, x2_ind) = get_indices(x, xs);
     let (y1_ind, y2_ind) = get_indices(y, ys);

--- a/src/twod_lut/interpolation.rs
+++ b/src/twod_lut/interpolation.rs
@@ -24,7 +24,8 @@ where
 
     if itertools::any(xs.clone(), |v| v.borrow().is_nan() || v.borrow().is_infinite())
         || itertools::any(ys.clone(), |v| v.borrow().is_nan() || v.borrow().is_infinite())
-        || surface.clone()
+        || surface
+            .clone()
             .into_iter()
             .any(|row| itertools::any(row, |v| v.borrow().is_nan() || v.borrow().is_infinite()))
     {
@@ -36,34 +37,6 @@ where
     if !itertools::all(itxs, |(prev, curr)| curr - prev > EPSILON)
         || !itertools::all(itys, |(prev, curr)| curr - prev > EPSILON)
     {
-        return Err("X and Y values should be in strictly increasing order".to_string());
-    }
-
-    Ok(true)
-}
-
-// TODO: Try to unify the two copies of the functions by using an Iterator implementation
-// or some other similar construct.
-
-pub(in crate::twod_lut) fn is_object_constructible_dynamic(
-    xs: &[f64],
-    ys: &[f64],
-    surface: &[&[f64]],
-) -> Result<bool, String> {
-    if xs.len() < 2 || ys.len() < 2 {
-        return Err("At least two values should be provided for x and y axes".to_string());
-    }
-
-    let check_nan_infinity = |v: &f64| v.is_nan() || v.is_infinite();
-
-    if xs.iter().any(check_nan_infinity)
-        || ys.iter().any(check_nan_infinity)
-        || surface.iter().any(|row| row.iter().any(check_nan_infinity))
-    {
-        return Err("Cannot create a Lookup Table containing NaNs or Infinities".to_string());
-    }
-
-    if !xs.windows(2).all(|c| c[1] - c[0] > EPSILON) || !ys.windows(2).all(|c| c[1] - c[0] > EPSILON) {
         return Err("X and Y values should be in strictly increasing order".to_string());
     }
 

--- a/src/twod_lut/interpolation.rs
+++ b/src/twod_lut/interpolation.rs
@@ -1,8 +1,7 @@
-use crate::twod_lut::{SurfaceType, SurfaceValueGetter};
+use crate::twod_lut::SurfaceValueGetter;
 use crate::EPSILON;
 use itertools::Itertools;
-use num::complex::ComplexFloat;
-use std::borrow::{Borrow, Cow};
+use std::borrow::Borrow;
 use std::iter::Iterator;
 use std::ops::Sub;
 
@@ -25,7 +24,6 @@ where
     if itertools::any(xs.clone(), |v| v.borrow().is_nan() || v.borrow().is_infinite())
         || itertools::any(ys.clone(), |v| v.borrow().is_nan() || v.borrow().is_infinite())
         || surface
-            .clone()
             .into_iter()
             .any(|row| itertools::any(row, |v| v.borrow().is_nan() || v.borrow().is_infinite()))
     {

--- a/src/twod_lut/interpolation.rs
+++ b/src/twod_lut/interpolation.rs
@@ -8,9 +8,9 @@ use std::ops::Sub;
 
 pub(in crate::twod_lut) fn is_object_constructible_gen<I, J, K>(xs: I, ys: J, surface: K) -> Result<bool, String>
 where
-    I: IntoIterator + Copy,
-    J: IntoIterator + Copy,
-    K: IntoIterator + Copy,
+    I: IntoIterator + Clone,
+    J: IntoIterator + Clone,
+    K: IntoIterator + Clone,
     I::Item: Borrow<f64> + Sub + Clone,
     <<I as IntoIterator>::Item as Sub>::Output: PartialOrd<f64>,
     J::Item: Borrow<f64> + Sub + Clone,
@@ -18,13 +18,13 @@ where
     K::Item: IntoIterator,
     <<K as IntoIterator>::Item as IntoIterator>::Item: Borrow<f64> + Sub + Clone,
 {
-    if xs.into_iter().count() < 2 || ys.into_iter().count() < 2 {
+    if xs.clone().into_iter().count() < 2 || ys.clone().into_iter().count() < 2 {
         return Err("At least two values should be provided for x and y axes".to_string());
     }
 
-    if itertools::any(xs, |v| v.borrow().is_nan() || v.borrow().is_infinite())
-        || itertools::any(ys, |v| v.borrow().is_nan() || v.borrow().is_infinite())
-        || surface
+    if itertools::any(xs.clone(), |v| v.borrow().is_nan() || v.borrow().is_infinite())
+        || itertools::any(ys.clone(), |v| v.borrow().is_nan() || v.borrow().is_infinite())
+        || surface.clone()
             .into_iter()
             .any(|row| itertools::any(row, |v| v.borrow().is_nan() || v.borrow().is_infinite()))
     {

--- a/src/twod_lut/interpolation.rs
+++ b/src/twod_lut/interpolation.rs
@@ -6,7 +6,7 @@ use std::borrow::{Borrow, Cow};
 use std::iter::Iterator;
 use std::ops::Sub;
 
-pub(in crate::twod_lut) fn is_object_constructible_gen<I, J, K>(xs: I, ys: J, surface: K) -> Result<bool, String>
+pub(in crate::twod_lut) fn is_object_constructible<I, J, K>(xs: I, ys: J, surface: K) -> Result<bool, String>
 where
     I: IntoIterator + Clone,
     J: IntoIterator + Clone,
@@ -104,49 +104,6 @@ pub(in crate::twod_lut) fn interpolate<const M: usize, const N: usize>(
 }
 
 pub(in crate::twod_lut) fn interpolate_dynamic(x: &f64, y: &f64, xs: &[f64], ys: &[f64], surface: &[&[f64]]) -> f64 {
-    // Retrieve the lower and upper bound indices for x and y axes.
-    let (x1_ind, x2_ind) = get_indices(x, xs);
-    let (y1_ind, y2_ind) = get_indices(y, ys);
-    let (x1, x2, y1, y2) = (xs[x1_ind], xs[x2_ind], ys[y1_ind], ys[y2_ind]);
-
-    // These represent the four corners of the quad, within which the interpolation is to be done.
-    let fq11 = surface[y1_ind][x1_ind];
-    let fq12 = surface[y1_ind][x2_ind];
-    let fq21 = surface[y2_ind][x1_ind];
-    let fq22 = surface[y2_ind][x2_ind];
-
-    // if both the indices are out of range, then return the corner point
-    // if one of the indices is out of range or maps to an exact breakpoint,
-    // then perform interpolation only in other direction.
-    // else perform interpolation on both the axes.
-    if fq11 == fq22 {
-        fq11
-    } else if fq11 == fq21 {
-        let alpha = (x - x1) / (x2 - x1);
-
-        fq11 + alpha * (fq12 - fq11)
-    } else if fq11 == fq12 {
-        let alpha = (y - y1) / (y2 - y1);
-
-        fq11 + alpha * (fq21 - fq11)
-    } else {
-        let alpha_x = (x - x1) / (x2 - x1);
-        let alpha_y = (y - y1) / (y2 - y1);
-
-        let fxy1 = fq11 + alpha_x * (fq21 - fq11);
-        let fxy2 = fq12 + alpha_x * (fq22 - fq12);
-
-        fxy1 + (fxy2 - fxy1) * alpha_y
-    }
-}
-
-pub(in crate::twod_lut) fn interpolate_dynamic_cow(
-    x: &f64,
-    y: &f64,
-    xs: &[f64],
-    ys: &[f64],
-    surface: &[Cow<'static, [f64]>],
-) -> f64 {
     // Retrieve the lower and upper bound indices for x and y axes.
     let (x1_ind, x2_ind) = get_indices(x, xs);
     let (y1_ind, y2_ind) = get_indices(y, ys);

--- a/src/twod_lut/mod.rs
+++ b/src/twod_lut/mod.rs
@@ -10,7 +10,8 @@
 mod interpolation;
 
 use crate::twod_lut::interpolation::{
-    interpolate, interpolate_dynamic, interpolate_dynamic_cow, is_object_constructible, is_object_constructible_dynamic,
+    interpolate, interpolate_dynamic, interpolate_dynamic_cow, is_object_constructible_dynamic,
+    is_object_constructible_gen,
 };
 use num::Float;
 use std::borrow::Cow;
@@ -58,7 +59,7 @@ impl<const M: usize, const N: usize> TwoDLookUpTable<M, N> {
     ///  assert_eq!(lut.err().unwrap(), "At least two values should be provided for x and y axes")
     /// ```
     pub fn new(xs: [f64; M], ys: [f64; N], surface: SurfaceType<M, N>) -> Result<TwoDLookUpTable<M, N>, String> {
-        is_object_constructible(&xs, &ys, &surface).map(|_| TwoDLookUpTable {
+        is_object_constructible_gen(&xs, &ys, &surface).map(|_| TwoDLookUpTable {
             x: xs,
             y: ys,
             surface,

--- a/src/twod_lut/mod.rs
+++ b/src/twod_lut/mod.rs
@@ -10,8 +10,7 @@
 mod interpolation;
 
 use crate::twod_lut::interpolation::{
-    interpolate, interpolate_dynamic, interpolate_dynamic_cow, is_object_constructible_dynamic,
-    is_object_constructible_gen,
+    interpolate, interpolate_dynamic, interpolate_dynamic_cow, is_object_constructible_gen,
 };
 use num::Float;
 use std::borrow::Cow;
@@ -100,7 +99,9 @@ pub struct TwoDLookUpTableRef<'a, 'b, 'c> {
 
 impl<'a, 'b, 'c> TwoDLookUpTableRef<'a, 'b, 'c> {
     pub fn new(xs: &'a [f64], ys: &'b [f64], surface: &'c [&'c [f64]]) -> Result<Self, String> {
-        is_object_constructible_dynamic(xs, ys, surface).map(|_| TwoDLookUpTableRef {
+        let mut vec = Vec::with_capacity(surface.len());
+        surface.iter().for_each(|v| vec.push(&v[0..v.len()]));
+        is_object_constructible_gen(xs.into_iter(), ys.into_iter(), vec.into_iter()).map(|_| TwoDLookUpTableRef {
             xs,
             ys,
             surface,
@@ -141,7 +142,7 @@ impl<'a, 'b> TwoDLookUpTableCow<'a, 'b> {
         ys: &'b [f64],
         surface: &'static Cow<'static, [Cow<'static, [f64]>]>,
     ) -> Result<Self, String> {
-        let mut vec = Vec::new();
+        let mut vec = Vec::with_capacity(surface.len());
         surface.iter().for_each(|v| vec.push(&v[0..v.len()]));
 
         // Since we are dealing with dynamic slices, align the xs and ys if the lengths are not aligned
@@ -177,5 +178,3 @@ impl<'a, 'b> TwoDLookUpTableCow<'a, 'b> {
         *self.cache.borrow().get(&key).unwrap()
     }
 }
-
-

--- a/src/twod_lut/mod.rs
+++ b/src/twod_lut/mod.rs
@@ -147,7 +147,7 @@ impl<'a, 'b> TwoDLookUpTableCow<'a, 'b> {
         // Since we are dealing with dynamic slices, align the xs and ys if the lengths are not aligned
         // according to the surface dimensions. If the lengths are same, then we assume that the xs and
         // ys are passed in the correct order.
-        is_object_constructible_dynamic(xs, ys, &vec).map(|_| TwoDLookUpTableCow {
+        is_object_constructible_gen(xs.into_iter(), ys.into_iter(), vec.into_iter()).map(|_| TwoDLookUpTableCow {
             xs,
             ys,
             surface,
@@ -177,3 +177,5 @@ impl<'a, 'b> TwoDLookUpTableCow<'a, 'b> {
         *self.cache.borrow().get(&key).unwrap()
     }
 }
+
+

--- a/src/twod_lut/mod.rs
+++ b/src/twod_lut/mod.rs
@@ -125,7 +125,7 @@ impl<'a, 'b, 'c> TwoDLookUpTableRef<'a, 'b, 'c> {
     pub fn new(xs: &'a [f64], ys: &'b [f64], surface: &'c [&'c [f64]]) -> Result<Self, String> {
         let mut vec = Vec::with_capacity(surface.len());
         surface.iter().for_each(|v| vec.push(&v[0..v.len()]));
-        is_object_constructible(xs.into_iter(), ys.into_iter(), vec.into_iter()).map(|_| TwoDLookUpTableRef {
+        is_object_constructible(xs.iter(), ys.iter(), vec.into_iter()).map(|_| TwoDLookUpTableRef {
             xs,
             ys,
             surface,
@@ -172,7 +172,7 @@ impl<'a, 'b> TwoDLookUpTableCow<'a, 'b> {
         // Since we are dealing with dynamic slices, align the xs and ys if the lengths are not aligned
         // according to the surface dimensions. If the lengths are same, then we assume that the xs and
         // ys are passed in the correct order.
-        is_object_constructible(xs.into_iter(), ys.into_iter(), vec.clone().into_iter()).map(|_| TwoDLookUpTableCow {
+        is_object_constructible(xs.iter(), ys.iter(), vec.clone().into_iter()).map(|_| TwoDLookUpTableCow {
             xs,
             ys,
             surface: vec,


### PR DESCRIPTION
This PR removes the duplicated functions created for is_object_constructible, and interpolation to reduce code duplication while still supporting the same structure types as before.