### PR TITLE
Remove dependency on std to make LUT usable in embedded environments

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,5 +18,9 @@ jobs:
     - uses: actions/checkout@v3
     - name: Build
       run: cargo build --verbose
+    - name: Build No-Std
+      run: cargo build --features no-std
     - name: Run tests
       run: cargo test --verbose
+    - name: Run tests No-std
+      run: cargo test --verbose --features no-std

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,22 @@ edition = "2021"
 [dependencies]
 num = "0.4.0"
 itertools = "0.10.5"
-heapless = "0.7.16"
-hashbrown = "0.14.0"
+heapless = {version="0.7.16", optional=true}
+hashbrown = {version="0.14.0", optional=true}
+
 
 [dev-dependencies]
 rstest = "0.17.0"
 
+[profile.release]
+debug = false
+lto = true
+strip = true
+panic="abort"
+codegen-units=1
+opt-level=3 # Although this option is to reduce size, this option sometimes increases the size
+
+[features]
+default = ["std"]
+std = []
+no-std = ["dep:heapless", "dep:hashbrown"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,6 @@ codegen-units=1
 opt-level=3 # Although this option is to reduce size, this option sometimes increases the size
 
 [features]
-default = ["std"]
-std = []
+default=[]
 no-std = ["dep:heapless", "dep:hashbrown"]
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,8 @@ edition = "2021"
 [dependencies]
 num = "0.4.0"
 itertools = "0.10.5"
-
+heapless = "0.7.16"
+hashbrown = "0.14.0"
 
 [dev-dependencies]
 rstest = "0.17.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 num = "0.4.0"
 itertools = "0.10.5"
+cfg-if = "1.0.0"
 heapless = {version="0.7.16", optional=true}
 hashbrown = {version="0.14.0", optional=true}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,15 +1,32 @@
 #![no_std]
 
+#[cfg(feature = "std")]
+extern crate std;
+
 mod oned_lut;
 mod twod_lut;
 
 pub(crate) const EPSILON: f64 = 0.00000001;
+
+#[cfg(feature = "no-std")]
 pub(crate) const MAX_FUNCTION_POINTS: usize = 1000;
+
+#[cfg(feature = "no-std")]
 const MAX_STRING_SIZE: usize = 100;
 
 pub use oned_lut::{OneDLookUpTable, OneDLookUpTableRef};
-pub use twod_lut::{TwoDLookUpTable, TwoDLookUpTableRef as TwoDLookUpTableCow, TwoDLookUpTableRef};
+pub use twod_lut::{TwoDLookUpTable, TwoDLookUpTableRef};
 
+//#[cfg(not(feature="std"))]
+#[cfg(feature = "no-std")]
 pub(crate) type String = heapless::String<MAX_STRING_SIZE>;
+//#[cfg(not(feature="std"))]
+#[cfg(feature = "no-std")]
 // Limit the elements to be stored in vector to 1000; For practical purposes this should suffice.
 pub(crate) type Vec<T> = heapless::Vec<T, MAX_FUNCTION_POINTS>;
+
+#[cfg(feature = "std")]
+pub(crate) type String = std::string::String;
+
+#[cfg(feature = "std")]
+pub(crate) type Vec<T> = std::vec::Vec<T>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,25 +8,20 @@ mod twod_lut;
 
 pub(crate) const EPSILON: f64 = 0.00000001;
 
-#[cfg(feature = "no-std")]
-pub(crate) const MAX_FUNCTION_POINTS: usize = 1000;
-
-#[cfg(feature = "no-std")]
-const MAX_STRING_SIZE: usize = 100;
-
+use cfg_if::cfg_if;
 pub use oned_lut::{OneDLookUpTable, OneDLookUpTableRef};
 pub use twod_lut::{TwoDLookUpTable, TwoDLookUpTableRef};
 
-//#[cfg(not(feature="std"))]
-#[cfg(feature = "no-std")]
-pub(crate) type String = heapless::String<MAX_STRING_SIZE>;
-//#[cfg(not(feature="std"))]
-#[cfg(feature = "no-std")]
-// Limit the elements to be stored in vector to 1000; For practical purposes this should suffice.
-pub(crate) type Vec<T> = heapless::Vec<T, MAX_FUNCTION_POINTS>;
+cfg_if! {
+    if #[cfg(feature = "std")] {
+        pub(crate) type String = std::string::String;
+        pub(crate) type Vec<T> = std::vec::Vec<T>;
+    } else if #[cfg(not(feature="std"))] {  // #[cfg(feature = "no-std")]
+        const MAX_STRING_SIZE: usize = 100;
+        pub(crate) const MAX_FUNCTION_POINTS: usize = 1000;
 
-#[cfg(feature = "std")]
-pub(crate) type String = std::string::String;
-
-#[cfg(feature = "std")]
-pub(crate) type Vec<T> = std::vec::Vec<T>;
+        pub(crate) type String = heapless::String<MAX_STRING_SIZE>;
+        // Limit the elements to be stored in vector to 1000; For practical purposes this should suffice.
+        pub(crate) type Vec<T> = heapless::Vec<T, MAX_FUNCTION_POINTS>;
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,15 @@
+#![no_std]
+
 mod oned_lut;
 mod twod_lut;
 
 pub(crate) const EPSILON: f64 = 0.00000001;
+pub(crate) const MAX_FUNCTION_POINTS: usize = 1000;
+const MAX_STRING_SIZE: usize = 100;
 
 pub use oned_lut::{OneDLookUpTable, OneDLookUpTableRef};
 pub use twod_lut::{TwoDLookUpTable, TwoDLookUpTableRef as TwoDLookUpTableCow, TwoDLookUpTableRef};
+
+pub(crate) type String = heapless::String<MAX_STRING_SIZE>;
+// Limit the elements to be stored in vector to 1000; For practical purposes this should suffice.
+pub(crate) type Vec<T> = heapless::Vec<T, MAX_FUNCTION_POINTS>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "no-std"))]
 extern crate std;
 
 mod oned_lut;
@@ -13,15 +13,15 @@ pub use oned_lut::{OneDLookUpTable, OneDLookUpTableRef};
 pub use twod_lut::{TwoDLookUpTable, TwoDLookUpTableRef};
 
 cfg_if! {
-    if #[cfg(feature = "std")] {
-        pub(crate) type String = std::string::String;
-        pub(crate) type Vec<T> = std::vec::Vec<T>;
-    } else if #[cfg(not(feature="std"))] {  // #[cfg(feature = "no-std")]
+    if #[cfg(feature="no-std")] {
         const MAX_STRING_SIZE: usize = 100;
         pub(crate) const MAX_FUNCTION_POINTS: usize = 1000;
 
         pub(crate) type String = heapless::String<MAX_STRING_SIZE>;
         // Limit the elements to be stored in vector to 1000; For practical purposes this should suffice.
         pub(crate) type Vec<T> = heapless::Vec<T, MAX_FUNCTION_POINTS>;
+    } else {
+        pub(crate) type String = std::string::String;
+        pub(crate) type Vec<T> = std::vec::Vec<T>;
     }
 }

--- a/src/oned_lut/interpolation.rs
+++ b/src/oned_lut/interpolation.rs
@@ -1,18 +1,19 @@
 use crate::EPSILON;
 
-pub(in crate::oned_lut) type Key = (u64, i16, i8);
+pub(super) type Key = (u64, i16, i8);
+use crate::String;
 
 pub(in crate::oned_lut) fn is_object_constructible(xs: &[f64], ys: &[f64]) -> Result<bool, String> {
     if xs.len() < 2 || ys.len() < 2 {
-        return Err("At least two values should be provided".to_string());
+        return Err(String::from("At least two values should be provided"));
     }
 
     if xs.iter().any(|v| v.is_nan() || v.is_infinite()) || ys.iter().any(|v| v.is_nan() || v.is_infinite()) {
-        return Err("Cannot create a Lookup Table containing NaNs or Infinities".to_string());
+        return Err(String::from("Cannot create a Lookup Table containing NaNs or Infinities"));
     }
 
     if !xs.windows(2).all(|c| c[1] - c[0] > EPSILON) {
-        return Err("X values should be in strictly increasing order".to_string());
+        return Err(String::from("X values should be in strictly increasing order"));
     }
 
     Ok(true)

--- a/src/oned_lut/mod.rs
+++ b/src/oned_lut/mod.rs
@@ -13,8 +13,11 @@ mod interpolation;
 use super::oned_lut::interpolation::{interpolate, is_object_constructible, Key};
 use crate::String;
 use core::cell::RefCell;
+#[cfg(feature = "no-std")]
 use hashbrown::HashMap;
 use num::Float;
+#[cfg(feature = "std")]
+use std::collections::HashMap;
 
 /// Linear interpolation with nearest neighbor extrapolation when index is outside support region,
 /// and with Caching support to enable fast lookups on same values.

--- a/src/oned_lut/mod.rs
+++ b/src/oned_lut/mod.rs
@@ -9,15 +9,20 @@
 //! Ofcourse when the values are out of bounds, then the last values are returned always.
 
 mod interpolation;
+use cfg_if::cfg_if;
 
 use super::oned_lut::interpolation::{interpolate, is_object_constructible, Key};
 use crate::String;
 use core::cell::RefCell;
-#[cfg(feature = "no-std")]
-use hashbrown::HashMap;
+cfg_if! {
+    if #[cfg(feature="no-std")] {
+        use hashbrown::HashMap;
+    } else {
+        use std::collections::HashMap;
+    }
+}
+
 use num::Float;
-#[cfg(feature = "std")]
-use std::collections::HashMap;
 
 /// Linear interpolation with nearest neighbor extrapolation when index is outside support region,
 /// and with Caching support to enable fast lookups on same values.

--- a/src/oned_lut/mod.rs
+++ b/src/oned_lut/mod.rs
@@ -9,18 +9,16 @@
 //! Ofcourse when the values are out of bounds, then the last values are returned always.
 
 mod interpolation;
-use cfg_if::cfg_if;
 
 use super::oned_lut::interpolation::{interpolate, is_object_constructible, Key};
 use crate::String;
 use core::cell::RefCell;
-cfg_if! {
-    if #[cfg(feature="no-std")] {
-        use hashbrown::HashMap;
-    } else {
-        use std::collections::HashMap;
-    }
-}
+
+#[cfg(not(feature = "no-std"))]
+use std::collections::HashMap;
+
+#[cfg(feature = "no-std")]
+use hashbrown::HashMap;
 
 use num::Float;
 

--- a/src/oned_lut/mod.rs
+++ b/src/oned_lut/mod.rs
@@ -11,9 +11,10 @@
 mod interpolation;
 
 use super::oned_lut::interpolation::{interpolate, is_object_constructible, Key};
+use crate::String;
+use core::cell::RefCell;
+use hashbrown::HashMap;
 use num::Float;
-use std::cell::RefCell;
-use std::collections::HashMap;
 
 /// Linear interpolation with nearest neighbor extrapolation when index is outside support region,
 /// and with Caching support to enable fast lookups on same values.

--- a/src/twod_lut/interpolation.rs
+++ b/src/twod_lut/interpolation.rs
@@ -1,11 +1,11 @@
 use crate::twod_lut::SurfaceValueGetter;
-use crate::EPSILON;
+use crate::{String, EPSILON};
+use core::borrow::Borrow;
+use core::iter::Iterator;
+use core::ops::Sub;
 use itertools::Itertools;
-use std::borrow::Borrow;
-use std::iter::Iterator;
-use std::ops::Sub;
 
-pub(in crate::twod_lut) fn is_object_constructible<I, J, K>(xs: I, ys: J, surface: K) -> Result<bool, String>
+pub(super) fn is_object_constructible<I, J, K>(xs: I, ys: J, surface: K) -> Result<bool, String>
 where
     I: IntoIterator + Clone,
     J: IntoIterator + Clone,
@@ -18,7 +18,7 @@ where
     <<K as IntoIterator>::Item as IntoIterator>::Item: Borrow<f64> + Sub + Clone,
 {
     if xs.clone().into_iter().count() < 2 || ys.clone().into_iter().count() < 2 {
-        return Err("At least two values should be provided for x and y axes".to_string());
+        return Err(String::from("At least two values should be provided for x and y axes"));
     }
 
     if itertools::any(xs.clone(), |v| v.borrow().is_nan() || v.borrow().is_infinite())
@@ -27,7 +27,7 @@ where
             .into_iter()
             .any(|row| itertools::any(row, |v| v.borrow().is_nan() || v.borrow().is_infinite()))
     {
-        return Err("Cannot create a Lookup Table containing NaNs or Infinities".to_string());
+        return Err(String::from("Cannot create a Lookup Table containing NaNs or Infinities"));
     }
 
     let itxs = xs.into_iter().tuple_windows::<(_, _)>();
@@ -35,7 +35,7 @@ where
     if !itertools::all(itxs, |(prev, curr)| curr - prev > EPSILON)
         || !itertools::all(itys, |(prev, curr)| curr - prev > EPSILON)
     {
-        return Err("X and Y values should be in strictly increasing order".to_string());
+        return Err(String::from("X and Y values should be in strictly increasing order"));
     }
 
     Ok(true)
@@ -58,7 +58,7 @@ fn get_indices(v: &f64, vs: &[f64]) -> (usize, usize) {
     }
 }
 
-pub(in crate::twod_lut) fn interpolate(x: &f64, y: &f64, xs: &[f64], ys: &[f64], obj: &dyn SurfaceValueGetter) -> f64 {
+pub(super) fn interpolate(x: &f64, y: &f64, xs: &[f64], ys: &[f64], obj: &dyn SurfaceValueGetter) -> f64 {
     // Retrieve the lower and upper bound indices for x and y axes.
     let (x1_ind, x2_ind) = get_indices(x, xs);
     let (y1_ind, y2_ind) = get_indices(y, ys);

--- a/src/twod_lut/mod.rs
+++ b/src/twod_lut/mod.rs
@@ -10,10 +10,19 @@
 mod interpolation;
 
 use crate::twod_lut::interpolation::{interpolate, is_object_constructible};
-use crate::{String, Vec, MAX_FUNCTION_POINTS};
+#[cfg(feature = "no-std")]
+use crate::MAX_FUNCTION_POINTS;
+use crate::{String, Vec};
+
 use core::cell::RefCell;
+#[cfg(feature = "no-std")]
 use hashbrown::HashMap;
 use num::Float;
+#[cfg(feature = "std")]
+use std::collections::HashMap;
+
+#[cfg(feature = "std")]
+use std::borrow::Cow;
 
 type Key = ((u64, i16, i8), (u64, i16, i8));
 
@@ -117,36 +126,15 @@ pub struct TwoDLookUpTableRef<'a, 'b, 'c> {
 }
 
 impl<'a, 'b, 'c> TwoDLookUpTableRef<'a, 'b, 'c> {
+    #[cfg(feature = "std")]
     #[allow(clippy::ptr_arg)]
-    //TODO: Allow this structure when std is enabled.
-    // pub fn new(
-    //     xs: &'a [f64],
-    //     ys: &'b [f64],
-    //     surface: &'static Cow<'static, [Cow<'static, [f64]>]>,
-    // ) -> Result<Self, String> {
-    //     //TODO: Unify the code for the functions new and new_ref
-    //     if xs.len() > MAX_FUNCTION_POINTS || ys.len() > MAX_FUNCTION_POINTS || surface.len() > MAX_FUNCTION_POINTS ||
-    //         surface.iter().any(|row| row.len() > MAX_FUNCTION_POINTS) {
-    //         return Err(String::from("Functions with more than {MAX_FUNCTION_POINTS} are not supported"));
-    //     }
-    //
-    //
-    //     let mut vec = Vec::new();
-    //     surface.iter().for_each(|v| vec.push(&v[0..v.len()]));
-    //
-    //     // Since we are dealing with dynamic slices, align the xs and ys if the lengths are not aligned
-    //     // according to the surface dimensions. If the lengths are same, then we assume that the xs and
-    //     // ys are passed in the correct order.
-    //     is_object_constructible(xs.iter(), ys.iter(), vec.clone().into_iter()).map(|_| TwoDLookUpTableRef {
-    //         xs,
-    //         ys,
-    //         surface: vec,
-    //         cache: RefCell::new(HashMap::new()),
-    //         xy_swapped: xs.len() != ys.len() && xs.len() == surface.len(),
-    //     })
-    // }
-
-    pub fn new_ref(xs: &'a [f64], ys: &'b [f64], surface: &'c [&'c [f64]]) -> Result<Self, String> {
+    pub fn from_cow(
+        xs: &'a [f64],
+        ys: &'b [f64],
+        surface: &'static Cow<'static, [Cow<'static, [f64]>]>,
+    ) -> Result<Self, String> {
+        #[cfg(feature = "no-std")]
+        //TODO: Unify the code for the functions from and new
         if xs.len() > MAX_FUNCTION_POINTS
             || ys.len() > MAX_FUNCTION_POINTS
             || surface.len() > MAX_FUNCTION_POINTS
@@ -156,7 +144,40 @@ impl<'a, 'b, 'c> TwoDLookUpTableRef<'a, 'b, 'c> {
         }
 
         let mut vec = Vec::new();
+        #[cfg(feature = "no-std")]
         surface.iter().for_each(|v| vec.push(&v[0..v.len()]).unwrap());
+
+        #[cfg(feature = "std")]
+        surface.iter().for_each(|v| vec.push(&v[0..v.len()]));
+
+        // Since we are dealing with dynamic slices, align the xs and ys if the lengths are not aligned
+        // according to the surface dimensions. If the lengths are same, then we assume that the xs and
+        // ys are passed in the correct order.
+        is_object_constructible(xs.iter(), ys.iter(), vec.clone().into_iter()).map(|_| TwoDLookUpTableRef {
+            xs,
+            ys,
+            surface: vec,
+            cache: RefCell::new(HashMap::new()),
+            xy_swapped: xs.len() != ys.len() && xs.len() == surface.len(),
+        })
+    }
+
+    pub fn new(xs: &'a [f64], ys: &'b [f64], surface: &'c [&'c [f64]]) -> Result<Self, String> {
+        #[cfg(feature = "no-std")]
+        if xs.len() > MAX_FUNCTION_POINTS
+            || ys.len() > MAX_FUNCTION_POINTS
+            || surface.len() > MAX_FUNCTION_POINTS
+            || surface.iter().any(|row| row.len() > MAX_FUNCTION_POINTS)
+        {
+            return Err(String::from("Functions with more than {MAX_FUNCTION_POINTS} are not supported"));
+        }
+
+        let mut vec = Vec::new();
+        #[cfg(feature = "no-std")]
+        surface.iter().for_each(|v| vec.push(&v[0..v.len()]).unwrap());
+
+        #[cfg(feature = "std")]
+        surface.iter().for_each(|v| vec.push(&v[0..v.len()]));
 
         // Since we are dealing with dynamic slices, align the xs and ys if the lengths are not aligned
         // according to the surface dimensions. If the lengths are same, then we assume that the xs and

--- a/tests/test_twod_lut.rs
+++ b/tests/test_twod_lut.rs
@@ -1,4 +1,4 @@
-use look_up_table::{TwoDLookUpTable, TwoDLookUpTableCow, TwoDLookUpTableRef};
+use look_up_table::{TwoDLookUpTable, TwoDLookUpTableRef};
 use rstest::{fixture, rstest};
 type IncrSurface = TwoDLookUpTable<5, 5>;
 


### PR DESCRIPTION
Using some replacement crates for Data Structures and String:
1. https://crates.io/crates/hashbrown  - For Hashmap support on Embedded systems. Ofcourse, as this crate claims, the security of the hashes is not as strict as that of stdlibrary.
2. https://docs.rs/crate/heapless/latest - Provides Vec, String and other datastructures, without allocator support.

Adds a no-std feature as selectable so that dependent crates can choose the dependencies appropriately.